### PR TITLE
Integration twin.macro

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+    "presets": [["next/babel", { "preset-react": { "runtime": "automatic" } }]],
+    "plugins": ["babel-plugin-macros", ["styled-components", { "ssr": true }]]
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,5 +80,6 @@ module.exports = {
         // See https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md
         // Use Record<string, unknown> instead of object
         "@typescript-eslint/ban-types": "error",
+        "@typescript-eslint/explicit-module-boundary-type": "off",
     },
 };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,29 @@
 {
     "editor.insertSpaces": true,
     "files.exclude": {
-        "**/.DS_Store": true,
         "**/.git": true,
-        "**/.hg": true,
-        "**/.next": true,
         "**/.svn": true,
+        "**/.hg": true,
         "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/.next": true,
         "**/node_modules": true
     },
     "prettier.disableLanguages": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
-    "prettier.tabWidth": 4
+    "prettier.tabWidth": 4,
+    "tailwindCSS.experimental.classRegex": [
+        // tw`...`
+        "tw`([^`]*)",
+
+        // <div tw="..." />
+        "tw=\"([^\"]*)",
+
+        // <div tw={"..."} />
+        "tw={\"([^\"}]*)",
+
+        // tw.xxx`...`
+        "tw\\.\\w+`([^`]*)",
+        ["classnames\\(([^)]*)\\)", "'([^']*)'"]
+    ],
+    "explorerExclude.backup": null
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,11 @@
+// next.config.js
+module.exports = {
+    webpack: (config, { isServer }) => {
+        // Fixes npm packages that depend on `fs` module
+        if (!isServer) {
+            config.node = { fs: "empty" };
+        }
+
+        return config;
+    },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,6 @@
             "version": "7.12.5",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
             "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.5",
                 "jsesc": "^2.5.1",
@@ -173,7 +172,6 @@
                     "version": "7.12.7",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
                     "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-                    "dev": true,
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.10.4",
                         "lodash": "^4.17.19",
@@ -183,8 +181,7 @@
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
                 }
             }
         },
@@ -192,7 +189,6 @@
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
             "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.10.4"
             },
@@ -201,7 +197,6 @@
                     "version": "7.12.7",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
                     "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-                    "dev": true,
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.10.4",
                         "lodash": "^4.17.19",
@@ -373,7 +368,6 @@
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
             "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-            "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.10.4",
                 "@babel/template": "^7.10.4",
@@ -384,7 +378,6 @@
                     "version": "7.12.7",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
                     "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-                    "dev": true,
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.10.4",
                         "lodash": "^4.17.19",
@@ -397,7 +390,6 @@
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
             "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.10.4"
             },
@@ -406,7 +398,6 @@
                     "version": "7.12.7",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
                     "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-                    "dev": true,
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.10.4",
                         "lodash": "^4.17.19",
@@ -463,7 +454,6 @@
             "version": "7.12.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
             "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.5"
             },
@@ -472,7 +462,6 @@
                     "version": "7.12.7",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
                     "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-                    "dev": true,
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.10.4",
                         "lodash": "^4.17.19",
@@ -636,7 +625,6 @@
             "version": "7.11.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
             "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.11.0"
             },
@@ -645,7 +633,6 @@
                     "version": "7.12.7",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
                     "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-                    "dev": true,
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.10.4",
                         "lodash": "^4.17.19",
@@ -727,8 +714,7 @@
         "@babel/parser": {
             "version": "7.12.7",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
-            "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
-            "dev": true
+            "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg=="
         },
         "@babel/plugin-proposal-async-generator-functions": {
             "version": "7.12.1",
@@ -1680,7 +1666,6 @@
             "version": "7.12.7",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
             "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/parser": "^7.12.7",
@@ -1691,7 +1676,6 @@
                     "version": "7.12.7",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
                     "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-                    "dev": true,
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.10.4",
                         "lodash": "^4.17.19",
@@ -1704,7 +1688,6 @@
             "version": "7.12.9",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
             "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/generator": "^7.12.5",
@@ -1721,7 +1704,6 @@
                     "version": "7.12.7",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
                     "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-                    "dev": true,
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.10.4",
                         "lodash": "^4.17.19",
@@ -1809,7 +1791,6 @@
             "version": "0.8.8",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
             "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-            "dev": true,
             "requires": {
                 "@emotion/memoize": "0.7.4"
             }
@@ -1817,8 +1798,7 @@
         "@emotion/memoize": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-            "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-            "dev": true
+            "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
         },
         "@emotion/serialize": {
             "version": "0.11.16",
@@ -1872,14 +1852,12 @@
         "@emotion/stylis": {
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-            "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-            "dev": true
+            "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
         },
         "@emotion/unitless": {
             "version": "0.7.5",
             "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-            "dev": true
+            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
         },
         "@emotion/utils": {
             "version": "0.11.3",
@@ -4414,8 +4392,7 @@
         "@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-            "dev": true
+            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "@types/parse5": {
             "version": "5.0.3",
@@ -4471,6 +4448,14 @@
                 "@types/react": "*"
             }
         },
+        "@types/react-native": {
+            "version": "0.63.40",
+            "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.40.tgz",
+            "integrity": "sha512-y98TQBjfncIrdDrwIhxcmcad1gHKNfUKFnCBk3heYy0Gvt6BNcBeSKRvACV4cf6R1K/cNJMoS3rjaMvYhQyAgw==",
+            "requires": {
+                "@types/react": "*"
+            }
+        },
         "@types/react-redux": {
             "version": "7.1.12",
             "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.12.tgz",
@@ -4505,6 +4490,17 @@
             "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
             "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
             "dev": true
+        },
+        "@types/styled-components": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.5.tgz",
+            "integrity": "sha512-VWwoKm39W783a75oILtdCjnNn+FSV8Yh3O9naIudtZCAkk+rRfwLWzuPjf5k/OilENgZqAkxJ9sukSOZTAD86g==",
+            "requires": {
+                "@types/hoist-non-react-statics": "*",
+                "@types/react": "*",
+                "@types/react-native": "*",
+                "csstype": "^3.0.2"
+            }
         },
         "@types/tapable": {
             "version": "1.0.6",
@@ -5737,7 +5733,6 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
             "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.7.2",
                 "cosmiconfig": "^6.0.0",
@@ -5870,6 +5865,17 @@
                     "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
                     "dev": true
                 }
+            }
+        },
+        "babel-plugin-styled-components": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz",
+            "integrity": "sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==",
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-module-imports": "^7.0.0",
+                "babel-plugin-syntax-jsx": "^6.18.0",
+                "lodash": "^4.17.11"
             }
         },
         "babel-plugin-syntax-jsx": {
@@ -6581,8 +6587,7 @@
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         },
         "camel-case": {
             "version": "4.1.1",
@@ -6603,6 +6608,11 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
+        },
+        "camelize": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+            "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
         },
         "caniuse-lite": {
             "version": "1.0.30001161",
@@ -6756,6 +6766,11 @@
             "requires": {
                 "source-map": "~0.6.0"
             }
+        },
+        "clean-set": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.2.tgz",
+            "integrity": "sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug=="
         },
         "clean-stack": {
             "version": "2.2.0",
@@ -7240,7 +7255,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
             "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-            "dev": true,
             "requires": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.1.0",
@@ -7422,6 +7436,11 @@
                 }
             }
         },
+        "css-color-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+            "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+        },
         "css-has-pseudo": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
@@ -7561,6 +7580,16 @@
                         "domelementtype": "1"
                     }
                 }
+            }
+        },
+        "css-to-react-native": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+            "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+            "requires": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
             }
         },
         "css-unit-converter": {
@@ -8053,6 +8082,11 @@
                 "react-is": "^16.13.1"
             }
         },
+        "dset": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/dset/-/dset-2.0.1.tgz",
+            "integrity": "sha512-nI29OZMRYq36hOcifB6HTjajNAAiBKSXsyWZrq+VniusseuP2OpNlTiYgsaNRSGvpyq5Wjbc2gQLyBdTyWqhnQ=="
+        },
         "duplexer": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -8290,7 +8324,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             },
@@ -8298,8 +8331,7 @@
                 "is-arrayish": {
                     "version": "0.2.1",
                     "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-                    "dev": true
+                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
                 }
             }
         },
@@ -9934,8 +9966,7 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "globalthis": {
             "version": "1.0.1",
@@ -10577,7 +10608,6 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
             "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
-            "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -10586,8 +10616,7 @@
                 "resolve-from": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-                    "dev": true
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
                 }
             }
         },
@@ -11482,8 +11511,7 @@
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
         },
         "json-buffer": {
             "version": "3.0.0",
@@ -11499,8 +11527,7 @@
         "json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "json-schema-traverse": {
             "version": "0.4.1",
@@ -11654,8 +11681,7 @@
         "lines-and-columns": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-            "dev": true
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
         },
         "lint-staged": {
             "version": "10.5.3",
@@ -11966,6 +11992,11 @@
             "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
             "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
             "dev": true
+        },
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
         },
         "lodash.sortby": {
             "version": "4.7.0",
@@ -13419,7 +13450,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
             }
@@ -13454,7 +13484,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
             "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -13529,8 +13558,7 @@
         "path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "pbkdf2": {
             "version": "3.1.1",
@@ -17026,8 +17054,7 @@
         "shallowequal": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-            "dev": true
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
         },
         "sharp": {
             "version": "0.26.2",
@@ -17482,6 +17509,11 @@
             "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
             "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
         },
+        "string-similarity": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.3.tgz",
+            "integrity": "sha512-QEwJzNFCqq+5AGImk5z4vbsEPTN/+gtyKfXBVLBcbPBRPNganZGfQnIuf9yJ+GiwSnD65sT8xrw/uwU1Q1WmfQ=="
+        },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -17641,6 +17673,33 @@
             "dev": true,
             "requires": {
                 "inline-style-parser": "0.1.1"
+            }
+        },
+        "styled-components": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.1.tgz",
+            "integrity": "sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==",
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/traverse": "^7.4.5",
+                "@emotion/is-prop-valid": "^0.8.8",
+                "@emotion/stylis": "^0.8.4",
+                "@emotion/unitless": "^0.7.4",
+                "babel-plugin-styled-components": ">= 1",
+                "css-to-react-native": "^3.0.0",
+                "hoist-non-react-statics": "^3.0.0",
+                "shallowequal": "^1.1.0",
+                "supports-color": "^5.5.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "styled-jsx": {
@@ -18136,6 +18195,11 @@
                 "setimmediate": "^1.0.4"
             }
         },
+        "timsort": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+            "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+        },
         "tiny-emitter": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -18302,6 +18366,84 @@
             "optional": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
+            }
+        },
+        "twin.macro": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/twin.macro/-/twin.macro-2.0.7.tgz",
+            "integrity": "sha512-AXLs9WAf3njusUVDMS6EGZOpxatsBokgSF6xTie/2hZ1MVHlDFz2ervL6O1FqiaWtu7Pi9/8HJLJILAmAUwlGg==",
+            "requires": {
+                "@babel/parser": "^7.12.5",
+                "babel-plugin-macros": "^2.8.0",
+                "chalk": "^4.1.0",
+                "clean-set": "^1.1.1",
+                "color": "^3.1.3",
+                "dset": "^2.0.1",
+                "lodash.merge": "^4.6.2",
+                "postcss": "^8.1.8",
+                "string-similarity": "^4.0.3",
+                "tailwindcss": "^2.0.1",
+                "timsort": "^0.3.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                },
+                "nanoid": {
+                    "version": "3.1.20",
+                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+                    "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
+                },
+                "postcss": {
+                    "version": "8.2.1",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.1.tgz",
+                    "integrity": "sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==",
+                    "requires": {
+                        "colorette": "^1.2.1",
+                        "nanoid": "^3.1.20",
+                        "source-map": "^0.6.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "type": {
@@ -19491,8 +19633,7 @@
         "yaml": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-            "dev": true
+            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
         },
         "yauzl": {
             "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,17 @@
             "pre-commit": "lint-staged"
         }
     },
+    "browserslist": [
+        ">0.3%",
+        "not ie <= 11",
+        "not dead",
+        "not op_mini all"
+    ],
+    "babelMacros": {
+        "twin": {
+            "preset": "styled-components"
+        }
+    },
     "dependencies": {
         "@reduxjs/toolkit": "^1.5.0",
         "@types/classnames": "^2.2.11",
@@ -22,11 +33,14 @@
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
         "@types/react-redux": "^7.1.12",
+        "@types/styled-components": "^5.1.5",
         "classnames": "^2.2.6",
         "next": "10.0.3",
         "react": "17.0.1",
         "react-dom": "17.0.1",
-        "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.1"
+        "styled-components": "^5.2.1",
+        "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.1",
+        "twin.macro": "^2.0.7"
     },
     "devDependencies": {
         "@babel/core": "^7.12.9",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,12 @@
-import "../styles/globals.css";
+import { GlobalStyles } from "twin.macro";
 import { AppProps } from "next/app";
 import { ReactElement } from "react";
 
 export default function MyApp({ Component, pageProps }: AppProps): ReactElement {
-    return <Component {...pageProps} />;
+    return (
+        <div>
+            <GlobalStyles />
+            <Component {...pageProps} />
+        </div>
+    );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import Document, { DocumentContext } from "next/document";
+import { ServerStyleSheet } from "styled-components";
+
+export default class MyDocument extends Document {
+    static async getInitialProps(ctx: DocumentContext) {
+        const sheet = new ServerStyleSheet();
+        const originalRenderPage = ctx.renderPage;
+        try {
+            ctx.renderPage = () =>
+                originalRenderPage({
+                    enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+                });
+            const initialProps = await Document.getInitialProps(ctx);
+
+            return {
+                ...initialProps,
+                styles: (
+                    <>
+                        {initialProps.styles}
+                        {sheet.getStyleElement()}
+                    </>
+                ),
+            };
+        } finally {
+            sheet.seal();
+        }
+    }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,15 +3,19 @@ import Head from "next/head";
 import { UnitExample } from "components/units/UnitExample";
 import { ReactElement } from "react";
 
+import tw from "twin.macro";
+
+const HomeContainer = tw.div`flex items-center justify-center w-full h-screen text-5xl text-gray-700 bg-gray-200`;
+
 export default function Home(): ReactElement {
     return (
         <>
             <Head>
-                <title>Mentory</title>
+                <title>Mentory ({process.env.NODE_ENV == "development" && "development"})</title>
             </Head>
-            <div className="flex items-center justify-center w-full h-screen text-5xl text-gray-700 bg-gray-200 ">
+            <HomeContainer>
                 <UnitExample title="Mentory" />
-            </div>
+            </HomeContainer>
         </>
     );
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    plugins: { "postcss-import": {}, tailwindcss: {}, "postcss-preset-env": {} },
+    plugins: { "postcss-import": {}, "postcss-preset-env": {} },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,17 +1,10 @@
 const colors = require("tailwindcss/colors");
 
 module.exports = {
-    purge: {
-        content: [
-            "./pages/**/*.tsx",
-            "./pages/**/*.html",
-            "./components/**/*.tsx",
-            "./layouts/**/*.tsx",
-        ],
-    },
     darkMode: false, // or 'media' or 'class'
     theme: {
         extend: {
+            // Enable all Tailwind color utilities
             colors: colors,
         },
     },

--- a/twin.d.ts
+++ b/twin.d.ts
@@ -1,0 +1,37 @@
+//
+// ────────────────────────────────────────────────────────────────────── I ──────────
+//   :::::: T W I N   M A C R O   T Y P E : :  :   :    :     :        :          :
+// ────────────────────────────────────────────────────────────────────────────────
+//
+//
+// ─── MODULE AGUMENTATION IN TYPESCRIPT TO EXTEND EXISTING TYPES WITH ADDITIONAL PROPERTIES
+//
+
+import "twin.macro";
+import styledImport, { CSSProp, css as cssImport } from "styled-components";
+
+declare module "twin.macro" {
+    // The styled and css imports
+    const styled: typeof styledImport;
+    const css: typeof cssImport;
+}
+
+declare module "react" {
+    // The css prop
+    interface HTMLAttributes<T> extends DOMAttributes<T> {
+        css?: CSSProp;
+    }
+    // The inline svg css prop
+    interface SVGProps<T> extends SVGProps<SVGSVGElement> {
+        css?: CSSProp;
+    }
+}
+
+// The 'as' prop on styled components
+declare global {
+    namespace JSX {
+        interface IntrinsicAttributes<T> extends DOMAttributes<T> {
+            as?: string;
+        }
+    }
+}


### PR DESCRIPTION
+ Twin.macro
+ Styled-components
- Removed Tailwind from PostCSS and let Twin.macro handle utility classes generation
- Removed requirement for ESLint `@typescript-eslint/explicit-module-boundary-type` for implicit type resolution on module export
- closes #10 