### PR TITLE
Patched lintstage pr template

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,7 +82,10 @@ module.exports = {
 
         // Turn off default no-unused-vars rule and use Typescript version instead
         "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+        "@typescript-eslint/no-unused-vars": [
+            "warn",
+            { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+        ],
 
         "react/prop-types": "off",
         "react/react-in-jsx-scope": "off",

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,10 +1,5 @@
-const micromatch = require("micromatch");
-
 module.exports = {
-    "**/*.{ts,tsx,js,jsx}": (names) => {
-        const tsFiles = micromatch.match(names, "*.{ts,tsx}");
-        return tsFiles
-            .map((f) => `tsc -p tsconfig.json --pretty --noEmit ${f}`)
-            .concat([`eslint ${names.join(" ")}`]);
+    "*.{ts,tsx,js,jsx}": (names) => {
+        return [`eslint ${names.join(" ")}`, "tsc --pretty --noEmit"];
     },
 };

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,25 @@
+# Purpose
+
+This PR (summary of this PR)
+Closes (issue)
+
+- [] Bug fix (non-breaking change which fixes an issue)
+- [] New feature (non-breaking change which adds functionality)
+- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+# Checklist
+
+- [] I have self-reviewed this PR
+- [] I have followed coding style guidelines of this project
+- [] I have not introduced new linting errors and warnings
+- [] I have commented part of the code that might be confusing or hard to understand
+- [] I have cleaned up WIP commits using Interactive Rebasing
+- [] I have rebased new changes into master and resolved any conflicts
+
+# List of changes
+
+- Added
+- Changed
+- Integrated
+- Fixed
+- Removed


### PR DESCRIPTION
This PR add redundant PR template in `docs`. It was removed because I thought putting it in `.github` would work but it doesn't.