### PR TITLE
Added window media query support for safari <= 13

### DIFF
--- a/hooks/useScreen.tsx
+++ b/hooks/useScreen.tsx
@@ -21,7 +21,7 @@ const ScreenProvider = ({ children, screens }: { children: ReactNode; screens: T
 
         const mediaData = Object.entries(screens).map(([name, media]) => [
             name,
-            `(min-width: ${media})`,
+            `only screen and (min-width: ${media})`,
         ]);
 
         const handleQueryListener = () => {
@@ -53,7 +53,12 @@ const ScreenProvider = ({ children, screens }: { children: ReactNode; screens: T
 
             mediaData.forEach(([name, media]) => {
                 if (typeof media !== "string") return;
-                mediaQueryLists[name].onchange = handleQueryListener;
+                try {
+                    mediaQueryLists[name].addEventListener("change", handleQueryListener);
+                } catch {
+                    // Support for Safari <= 13
+                    mediaQueryLists[name].addListener(handleQueryListener);
+                }
             });
         }
 
@@ -61,7 +66,12 @@ const ScreenProvider = ({ children, screens }: { children: ReactNode; screens: T
             if (!isAttached) return;
             mediaData.forEach(([name, media]) => {
                 if (typeof media !== "string") return;
-                mediaQueryLists[name].onchange = null;
+                try {
+                    mediaQueryLists[name].removeEventListener("change", handleQueryListener);
+                } catch {
+                    // Support for Safari <= 13
+                    mediaQueryLists[name].removeListener(handleQueryListener);
+                }
             });
         };
     }, [screens]);


### PR DESCRIPTION
# Purpose

This PR fixes issue with older version of Safari that don't support `onchange` property on `mediaQueryList` object.
Closes (#57 )

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have self-reviewed this PR
- [x] I have followed coding style guidelines of this project
- [x] I have not introduced new linting errors and warnings
- [x] I have commented part of the code that might be confusing or hard to understand
- [x] I have cleaned up WIP commits using Interactive Rebasing
- [x] I have rebased new changes into master and resolved any conflicts

# List of changes

- Added support for older version of safari